### PR TITLE
Fix - make sure the track! function properly sets the first-time variable. [SV-948]

### DIFF
--- a/src/vimsical/re_frame/fx/track.cljc
+++ b/src/vimsical/re_frame/fx/track.cljc
@@ -79,12 +79,12 @@
   [{:keys [subscription event-fn dispatch-first?] :or {dispatch-first? true}}]
   {:pre [(vector? subscription) (ifn? event-fn)]}
   #?(:cljs
-     (let [first-time-ref? (atom true)]
+     (let [first-time-ref (atom true)]
        (ratom/track!
         (fn []
           (let [sub-value @(re-frame/subscribe subscription)
                 first-time? @first-time-ref]
-            (reset! first-time-ref? false)
+            (reset! first-time-ref false)
             (when-some [event-vector (event-fn sub-value)]
               (when (or dispatch-first?
                         (not first-time?))

--- a/src/vimsical/re_frame/fx/track.cljc
+++ b/src/vimsical/re_frame/fx/track.cljc
@@ -79,14 +79,15 @@
   [{:keys [subscription event-fn dispatch-first?] :or {dispatch-first? true}}]
   {:pre [(vector? subscription) (ifn? event-fn)]}
   #?(:cljs
-     (let [dispatched-first? (atom false)]
+     (let [first-time-ref? (atom true)]
        (ratom/track!
         (fn []
-          (let [sub-value @(re-frame/subscribe subscription)]
+          (let [sub-value @(re-frame/subscribe subscription)
+                first-time? @first-time-ref]
+            (reset! first-time-ref? false)
             (when-some [event-vector (event-fn sub-value)]
               (when (or dispatch-first?
-                        @dispatched-first?
-                        (do (reset! dispatched-first? true) nil))
+                        (not first-time?))
                 (re-frame/dispatch event-vector)))))))))
 
 


### PR DESCRIPTION
This fixes a bug where you register a subscription and :dispatch-first=false, then return nil from the event-function, the event won't be dispatched on a subsequent call.